### PR TITLE
Add legacy entry point [tool.setuptools.entry-points.'console_scripts']

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ Changelog = "https://github.com/aidee-health/embody-file/releases"
 [project.scripts]
 embody-file = "embodyfile.cli:main"
 
+[tool.setuptools.entry-points."console_scripts"]
+embody-file = "embodyfile.cli:main"
+
 [tool.hatch.build.targets.sdist]
 include = ["src/embodyfile"]
 
@@ -54,7 +57,7 @@ source = ["embodyfile", "tests"]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 2 # Increase once we have refactored and added tests
+fail_under = 2
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
This pull request includes updates to the `pyproject.toml` file to improve script entry-point configuration and clean up coverage settings.

Configuration improvements:

* Added a new `[tool.setuptools.entry-points."console_scripts"]` section to define the `embody-file` script entry point, ensuring compatibility with setuptools-based installations. (`[pyproject.tomlR38-R40](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R38-R40)`)
