### PR TITLE
Bug fix file extension

### DIFF
--- a/src/embodyfile/embodyfile.py
+++ b/src/embodyfile/embodyfile.py
@@ -15,7 +15,7 @@ from .parser import read_data
 def process_file(
     input_path: Path,
     output_path_base: Path,
-    output_formats=("HDF",),
+    output_formats=("HDF_LEGACY",),
     fail_on_errors=False,
     samplerate="1000",
 ) -> None:
@@ -38,7 +38,7 @@ def process_file(
     # Process each requested output format
     for format_name in output_formats:
         format = format_name.upper()
-        output_path = output_path_base
+        output_path = output_path_base.with_suffix("")
 
         exporter: BaseExporter | None = None
         if format == "CSV":

--- a/src/embodyfile/embodyfile.py
+++ b/src/embodyfile/embodyfile.py
@@ -38,7 +38,7 @@ def process_file(
     # Process each requested output format
     for format_name in output_formats:
         format = format_name.upper()
-        output_path = output_path_base.with_suffix(f".{format.lower()}")
+        output_path = output_path_base
 
         exporter: BaseExporter | None = None
         if format == "CSV":

--- a/src/embodyfile/exporters/csv_exporter.py
+++ b/src/embodyfile/exporters/csv_exporter.py
@@ -39,8 +39,8 @@ class CSVExporter(BaseExporter):
 
             info = {k: [v] for k, v in asdict(data.device_info).items()}
             device_info = pd.DataFrame(info)
-            device_info_file = get_output_path(output_path, "deviceinfo", self.FILE_EXTENSION)
-            self._export_dataframe(device_info, device_info_file, "deviceinfo")
+            device_info_file = get_output_path(output_path, "device_info", self.FILE_EXTENSION)
+            self._export_dataframe(device_info, device_info_file, "device_info")
             logging.info(f"Exported device info to CSV format: {device_info_file}")
 
         if logging.getLogger().isEnabledFor(logging.INFO):

--- a/src/embodyfile/exporters/hdf_exporter.py
+++ b/src/embodyfile/exporters/hdf_exporter.py
@@ -63,7 +63,7 @@ class HDFExporter(BaseExporter):
 
             info = {k: [v] for k, v in asdict(data.device_info).items()}
             pd.DataFrame(info).to_hdf(output_path, key="device_info", mode="a", complevel=4)
-            exported_schemas.append("deviceinfo")
+            exported_schemas.append("device_info")
 
         if exported_schemas:
             logging.info(f"Exported schemas {', '.join(exported_schemas)} to HDF file: {output_path}")

--- a/src/embodyfile/exporters/parquet_exporter.py
+++ b/src/embodyfile/exporters/parquet_exporter.py
@@ -38,8 +38,8 @@ class ParquetExporter(BaseExporter):
 
             info = {k: [v] for k, v in asdict(data.device_info).items()}
             device_info = pd.DataFrame(info)
-            device_info_file = get_output_path(output_path, "deviceinfo", self.FILE_EXTENSION)
-            self._export_dataframe(device_info, device_info_file, "deviceinfo")
+            device_info_file = get_output_path(output_path, "device_info", self.FILE_EXTENSION)
+            self._export_dataframe(device_info, device_info_file, "device_info")
 
         logging.info(f"Exported {len(exported_files)} files to Parquet format")
 

--- a/tests/test_parquet_exporter.py
+++ b/tests/test_parquet_exporter.py
@@ -42,7 +42,7 @@ def test_parquet_export():
         acc_file = find_schema_file(temp_dir, "test_output", "acc", "parquet")
         gyro_file = find_schema_file(temp_dir, "test_output", "gyro", "parquet")
         ecgppg_file = find_schema_file(temp_dir, "test_output", "ecgppg", "parquet")
-        device_info_file = find_schema_file(temp_dir, "test_output", "deviceinfo", "parquet")
+        device_info_file = find_schema_file(temp_dir, "test_output", "device_info", "parquet")
 
         if len(data.acc) > 0:
             assert acc_file.exists()
@@ -87,7 +87,7 @@ def test_parquet_export_multi_ecg_ppg():
         assert not df.empty
         assert "timestamp" in df.columns, f"Expected 'timestamp' column but got: {df.columns}"
 
-        device_info_file = find_schema_file(temp_dir, "test_output", "deviceinfo", "parquet")
+        device_info_file = find_schema_file(temp_dir, "test_output", "device_info", "parquet")
         assert device_info_file and device_info_file.exists(), "Device info file not found"
         df = pd.read_parquet(device_info_file)
         assert not df.empty


### PR DESCRIPTION
This pull request includes a change to the `process_file` function in `src/embodyfile/embodyfile.py`. The change removes the logic for appending a file extension based on the output format and instead uses the base output path directly.

- [`src/embodyfile/embodyfile.py`](diffhunk://#diff-8906b7b33bed63bbd43b975ad0d393f5c91f041da4b5b37cdb2eed832ae6cd15L41-R41): Updated the `process_file` function to stop appending file extensions for each output format, simplifying the output path handling.