### PR TITLE
Bump version to 1.0.27

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "embody-file"
-version = "1.0.26"
+version = "1.0.27"
 description = "Embody file converter"
 license = "MIT"
 classifiers = ["Development Status :: 5 - Production/Stable"]

--- a/uv.lock
+++ b/uv.lock
@@ -133,7 +133,7 @@ wheels = [
 
 [[package]]
 name = "embody-file"
-version = "1.0.26"
+version = "1.0.27"
 source = { editable = "." }
 dependencies = [
     { name = "embody-codec" },


### PR DESCRIPTION
This pull request includes a version bump for the `embody-file` project in the `pyproject.toml` file. The version has been updated from `1.0.26` to `1.0.27` to reflect the latest changes.