### PR TITLE
Improve sampling frequency indication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ __pycache__/
 #vs code
 .vscode/
 *.code-workspace
+
+# Coding agents
+.claude/
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -73,6 +73,30 @@ embody-file testfiles/v5_0_0_test_file.log --output-format HDF
 
 The file will be named the same as the input file, with the `.hdf` extension at the end of the file name.
 
+#### Reading HDF Metadata
+
+The HDF files store sampling frequency as metadata attributes rather than on the DataFrame index. This approach handles real-world sensor data that may have timing variations or gaps.
+
+To access the sampling frequency from HDF files:
+
+```python
+import pandas as pd
+
+# Read the data
+df = pd.read_hdf('your_file.hdf', key='multidata')
+
+# Access sampling frequency metadata
+with pd.HDFStore('your_file.hdf', mode='r') as store:
+    attrs = store.get_storer('multidata').attrs
+    if hasattr(attrs, 'sample_frequency_hz'):
+        print(f"Sampling frequency: {attrs.sample_frequency_hz} Hz")
+        print(f"Sample period: {attrs.sample_period_ms} ms")
+```
+
+Available metadata attributes:
+- `sample_frequency_hz`: The sampling frequency in Hertz
+- `sample_period_ms`: The sampling period in milliseconds
+
 ### Convert binary embody file to CSV
 
 To convert to CSV format, run the following:
@@ -133,11 +157,6 @@ Make a note from the parser's error output of what position the first error star
 
 - Look at the preceding bytes to see whether there were any errors in the previous protocol message
 - Look at the bytes from the reported (error) position to see if there are just a few bytes before a new, plausible protocol message starts
-
-## Contributing
-
-Contributions are very welcome.
-To learn more, see the [Contributor Guide].
 
 ## Issues
 

--- a/tests/test_hdf_exporter.py
+++ b/tests/test_hdf_exporter.py
@@ -104,7 +104,14 @@ def test_multi_block_ecg_2_channel_ppg():
         df_ecgppg = pd.read_hdf(output_path, key="ecgppg")
         assert isinstance(df_ecgppg, pd.DataFrame), "ecgppg is not a DataFrame"
         assert not df_ecgppg.empty, "ecgppg DataFrame is empty"
-        assert df_ecgppg.index.freq == pd.Timedelta("1ms"), "ecgppg index frequency is not 1ms"
+
+        # Check that frequency is stored as metadata
+        with pd.HDFStore(output_path, mode="r") as store:
+            attrs = store.get_storer("ecgppg").attrs
+            assert hasattr(attrs, "sample_frequency_hz"), "sample_frequency_hz not in metadata"
+            assert attrs.sample_frequency_hz == 1000, f"Expected 1000 Hz, got {attrs.sample_frequency_hz}"
+            assert hasattr(attrs, "sample_period_ms"), "sample_period_ms not in metadata"
+            assert attrs.sample_period_ms == 1.0, f"Expected 1.0 ms, got {attrs.sample_period_ms}"
 
 
 @pytest.mark.integtest


### PR DESCRIPTION
This pull request updates how sampling frequency information is stored and accessed in HDF export files. Instead of setting the frequency on the DataFrame index, the sampling frequency and period are now saved as metadata attributes in the HDF file. This change improves compatibility with real-world sensor data that may have timing gaps or irregularities. Documentation and tests are updated accordingly.

**HDF Exporter and Legacy Exporter Changes:**

* The sampling frequency (`sample_frequency_hz`) and period (`sample_period_ms`) are now stored as metadata attributes in the HDF files, rather than setting `df.index.freq`. This is done for both the main and legacy exporters. [[1]](diffhunk://#diff-aa0fe458bc6609e67b3fccbcc6d87951e4b960ced80db50be83d77acc8d7567dR90-R97) [[2]](diffhunk://#diff-7acb4c4094cafd8391928d99e15c0bfc992bb654fb7391bbf7c977647b6c00c7R58-R65)

**Documentation Updates:**

* The `README.md` now explains how to access the sampling frequency from HDF file metadata, including example code and a list of available metadata attributes.

**Testing Improvements:**

* Tests for both exporters are updated to check that the sampling frequency and period are correctly stored and retrievable from HDF file metadata, instead of checking the DataFrame index frequency. [[1]](diffhunk://#diff-7a88ca67e5a1b634f8c02b54ce1b6a20510fa515b1f8d4b1d3c1caee6db919b9L107-R114) [[2]](diffhunk://#diff-5a287790a63f023e91cb28313b55a85504cd1eeefb284579f418722fdf867a45L116-R123)
* The legacy exporter test utility now logs the frequency and period from metadata if present.

**Other:**

* The "Contributing" section was removed from the `README.md` for clarity.