### PR TITLE
Maintenance release 1.0.30

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "embody-file"
-version = "1.0.29"
+version = "1.0.30"
 description = "Embody file converter"
 license = "MIT"
 classifiers = ["Development Status :: 5 - Production/Stable"]

--- a/uv.lock
+++ b/uv.lock
@@ -148,7 +148,7 @@ wheels = [
 
 [[package]]
 name = "embody-file"
-version = "1.0.29"
+version = "1.0.30"
 source = { editable = "." }
 dependencies = [
     { name = "embody-codec" },


### PR DESCRIPTION
This pull request focuses on improving the stability and compatibility of the HDF export process in the legacy exporter, while also incrementing the package version. The main change is reverting to the use of multiple `to_hdf` calls instead of a single `HDFStore` context, due to compatibility issues with certain PyTables versions.

**HDF Export Stability and Compatibility:**

* [`src/embodyfile/exporters/hdf_legacy_exporter.py`](diffhunk://#diff-7acb4c4094cafd8391928d99e15c0bfc992bb654fb7391bbf7c977647b6c00c7L57-R79): Switched from using a single `HDFStore` context for all writes to using multiple `to_hdf` calls, addressing cleanup errors with some PyTables versions and improving backward compatibility. Metadata for sampling frequency is still stored as attributes on the "multidata" group.

**Version Update:**

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Bumped the package version from `1.0.29` to `1.0.30` to reflect the changes.